### PR TITLE
Plugin method should accept string variable as argument

### DIFF
--- a/tests/LaminasIntegration/data/pluginMethodDynamicReturn-2.json
+++ b/tests/LaminasIntegration/data/pluginMethodDynamicReturn-2.json
@@ -1,7 +1,12 @@
 [
     {
         "message": "Call to an undefined method Laminas\\View\\Helper\\Url::foobar().",
-        "line": 21,
+        "line": 22,
+        "ignorable": true
+    },
+    {
+        "message": "Call to an undefined method Laminas\\View\\Helper\\AbstractHelper::foobar().",
+        "line": 28,
         "ignorable": true
     }
 ]

--- a/tests/LaminasIntegration/data/pluginMethodDynamicReturn.php
+++ b/tests/LaminasIntegration/data/pluginMethodDynamicReturn.php
@@ -6,6 +6,7 @@ namespace LaminasPhpStan\Tests\LaminasIntegration\data;
 
 use Laminas\Router\SimpleRouteStack;
 use Laminas\View\Renderer\PhpRenderer;
+use Laminas\View\Helper\AbstractHelper;
 
 final class pluginMethodDynamicReturn
 {
@@ -14,10 +15,22 @@ final class pluginMethodDynamicReturn
      */
     private $phpRenderer;
 
-    public function getDynamicType(): void
+    public function getDynamicTypeFromStaticString(): void
     {
         $urlHelper = $this->phpRenderer->plugin('url');
         $urlHelper->setRouter(new SimpleRouteStack());
         $urlHelper->foobar();
     }
+
+    public function callGetDynamicTypeFromVariable(): void
+    {
+        $urlHelper = $this->getDynamicTypeFromStringVariable('url');
+        $urlHelper->foobar();
+    }
+
+    public function getDynamicTypeFromStringVariable(string $name): AbstractHelper
+    {
+        return $this->phpRenderer->plugin($name);
+    }
+
 }


### PR DESCRIPTION
Fix error "Internal error: Argument passed to Laminas\View\Renderer\PhpRenderer::plugin should be a string, string given" when ViewModel->plugin is called with a variable containing a string instead of a pure string: 

```php
$name = 'form';

// ...

$this->getView()->plugin($name);

```