### PR TITLE
Enable manual workflow run

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - "master"
+  workflow_dispatch:
 
 jobs:
   composer-json-lint:


### PR DESCRIPTION
Progress over at my PR #39 has stalled because the build is not passing.

I want to highlight that AFAICT all the issues appearing over there also apply to the current master state.

This PR simply allows to run the integration workflow manually, not just for PRs and master merges.
This will allow you (the maintainer) to check the result of a master build at any given time.
Once you see that there are issues on master, you can take appropriate measures to solve the issues.